### PR TITLE
Allow debugger to be a warning

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -13,7 +13,7 @@ module.exports = {
     'no-control-regex': 'error',
 
     // disallow use of debugger
-    'no-debugger': 'error',
+    'no-debugger': 'warn',
 
     // disallow duplicate arguments in functions
     'no-dupe-args': 'error',


### PR DESCRIPTION
When I'm debugging, if debugger is an error, I can't use it to break into specific positions in code.