### PR TITLE
[PLT-2018] Add eslint rule for import organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-riipen",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Riipen's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-riipen",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Riipen's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -113,7 +113,7 @@ module.exports = {
     //       https://github.com/benmosher/eslint-plugin-import/pull/629 is resolved.
     'import/order': ['error', {
       groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-      'newlines-between': 'always',
+      'newlines-between': 'always-and-inside-groups',
     }],
 
     // Require a newline after the last import/require in a group

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -109,10 +109,11 @@ module.exports = {
 
     // Enforce a convention in module import order
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
-    // TODO: enable?
-    'import/order': ['off', {
+    // TODO: enforce alphabetization within groups if/when
+    //       https://github.com/benmosher/eslint-plugin-import/pull/629 is resolved.
+    'import/order': ['error', {
       groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-      'newlines-between': 'never',
+      'newlines-between': 'always',
     }],
 
     // Require a newline after the last import/require in a group


### PR DESCRIPTION
*Link to Jira ticket: [[PLT-2018]](https://riipen.atlassian.net/browse/PLT-2018)*

When I started this JIRA task I thought a lot about how we should organize imports. I think it boils down to: using a linting configuration means it will be consistently enforced (1 less thing to think about huzzah!). This configuration chunks imports going down in specificity until (builtins -> within module). There is a PR to also alphabetize within sections (linked in the comment), which I believe we should do if/when it lands.

I have opened up a [PR](https://github.com/riipen/web/pull/839) with an example of what this eslint configuration enforces.

Do I have to bump the version number here and in the projects that use it to ensure this update gets seen?